### PR TITLE
docker images python 3.6 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM python:2.7
+FROM python:3.6
 
 
 RUN apt-get update && apt-get upgrade -y && apt-get autoremove && apt-get autoclean


### PR DESCRIPTION
I had noted that you use docker image of python 2.7 but after you go to install python3-dev...
so I had tested directly witth docker images of python 3.7 but seems not compatible with django.1.11.
With docker images of python 3.6 seems run...

So i don't know if there some reason for use image of Python 2.7 or not...